### PR TITLE
fix: prevent bad codemeta.programmingLanguage parsing

### DIFF
--- a/codemeticulous/codemeta/models.py
+++ b/codemeticulous/codemeta/models.py
@@ -54,7 +54,7 @@ class CodeMetaV3(ByAliasExcludeNoneMixin, BaseModel):
 
     codeRepository: Optional[AnyUrl]
     programmingLanguage: Optional[
-        VersionedLanguage | str | list[VersionedLanguage | str]
+        list[VersionedLanguage | str] | VersionedLanguage | str
     ]
     runtimePlatform: Optional[str | list[str]]
     targetProduct: Optional[list[SoftwareApplication | str] | SoftwareApplication | str]

--- a/tests/data/codemeta/clean/programmingLanguageList.expected.json
+++ b/tests/data/codemeta/clean/programmingLanguageList.expected.json
@@ -1,0 +1,12 @@
+{
+  "@context": "https://w3id.org/codemeta/3.0",
+  "@type": "SoftwareSourceCode",
+  "name": "Software with language list",
+  "programmingLanguage": [
+    {
+      "name": "typescript",
+      "@type": "ComputerLanguage"
+    }
+  ]
+}
+

--- a/tests/data/codemeta/clean/programmingLanguageList.json
+++ b/tests/data/codemeta/clean/programmingLanguageList.json
@@ -1,0 +1,12 @@
+{
+  "@context": "https://w3id.org/codemeta/3.0",
+  "@type": "SoftwareSourceCode",
+  "name": "Software with language list",
+  "programmingLanguage": [
+    {
+      "name": "typescript",
+      "@type": "ComputerLanguage"
+    }
+  ]
+}
+


### PR DESCRIPTION
type hint ordering matters for Pydantic v1, previously if we were initializing a CodeMeta object from a dict, it would attempt to cast a list of languages to a dict, wreaking havoc